### PR TITLE
refactor: board hook

### DIFF
--- a/data.json
+++ b/data.json
@@ -31,23 +31,47 @@
       "id": "1887n1pg5"
     },
     {
-      "title": "New boardasdfasdfsdfsdfsdfsdf",
+      "title": "New boardasdf",
       "createdAt": 1681814834964,
-      "updatedAt": 1682576219425,
+      "updatedAt": 1682579501758,
       "id": "c3z7zldac"
     },
     {
-      "title": "New boardasdfasdfㅏs어ㅗㄹㅁ니ㅏㅇ러ㅣㅁ나ㅓ리ㅏㅁㄴㅇㄹㄹㄴㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗㄹㅁㅗ",
+      "title": "New boardasdfasd",
       "createdAt": 1681814835481,
-      "updatedAt": 1682018538780,
+      "updatedAt": 1682579508123,
       "id": "btkpvtws4"
+    },
+    {
+      "title": "New board",
+      "createdAt": 1682580527430,
+      "updatedAt": 1682580527430,
+      "id": "61w5ldags"
+    },
+    {
+      "title": "New board",
+      "createdAt": 1682580527511,
+      "updatedAt": 1682580527511,
+      "id": "1wd3pgufd"
+    },
+    {
+      "title": "New board",
+      "createdAt": 1682580528942,
+      "updatedAt": 1682580528942,
+      "id": "v334zxfx2"
+    },
+    {
+      "title": "New board",
+      "createdAt": 1682580529492,
+      "updatedAt": 1682580529492,
+      "id": "goi43ojmf"
     }
   ],
-  "taskList": [
+  "taskLists": [
     {
       "id": "taskList1",
       "title": "To do",
-      "boardId": "board1",
+      "boardId": "c3z7zldac",
       "tasks": [
         {
           "id": "task1",
@@ -66,7 +90,7 @@
     {
       "id": "taskList2",
       "title": "In progress",
-      "boardId": "board1",
+      "boardId": "c3z7zldac",
       "tasks": [
         {
           "id": "task4",
@@ -85,7 +109,7 @@
     {
       "id": "taskList3",
       "title": "Done",
-      "boardId": "board1",
+      "boardId": "c3z7zldac",
       "tasks": [
         {
           "id": "task7",

--- a/src/api/task-lists/get-task-lists.ts
+++ b/src/api/task-lists/get-task-lists.ts
@@ -1,0 +1,10 @@
+import { getTaskListsPath } from '@/api/task-lists/path';
+import { fetcher } from '@/utils/api-client';
+
+export type GetTaskListsParams = {
+  boardID: string;
+};
+
+export const getTaskListsAPI = async ({ boardID }: GetTaskListsParams) => {
+  return await fetcher(getTaskListsPath(boardID));
+};

--- a/src/api/task-lists/path.ts
+++ b/src/api/task-lists/path.ts
@@ -1,0 +1,4 @@
+export const getTaskListsPath = (boardID: string) =>
+  `taskLists?boardId=${boardID}`;
+
+export const getTaskListPath = (id: string) => `taskLists/${id}`;

--- a/src/components/board-content/index.tsx
+++ b/src/components/board-content/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 
 import { TaskList } from '@/components/task-list';
@@ -5,12 +6,13 @@ import { Flex } from '@chakra-ui/react';
 
 import type { TaskListType } from '@/types/task-list.type';
 import type { DropResult } from 'react-beautiful-dnd';
-
 interface Props {
   taskLists: TaskListType[];
 }
 
-export function BoardContent({ taskLists }: Props) {
+export function BoardContent({ taskLists: list }: Props) {
+  const [taskLists, setTaskLists] = useState<TaskListType[]>(list);
+
   const reorder = (
     lists: TaskListType[],
     startIndex: number,

--- a/src/components/board-content/index.tsx
+++ b/src/components/board-content/index.tsx
@@ -1,28 +1,21 @@
-import { useState } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 
 import { TaskList } from '@/components/task-list';
 import { Flex } from '@chakra-ui/react';
 
+import type { TaskListType } from '@/types/task-list.type';
 import type { DropResult } from 'react-beautiful-dnd';
 
-interface TaskList {
-  id: string;
-  name: string;
-  tasks: Task[];
+interface Props {
+  taskLists: TaskListType[];
 }
 
-interface Task {
-  id: string;
-  name: string;
-  description: string;
-  completed: boolean;
-}
-
-export function BoardContent() {
-  const [taskLists, setTaskLists] = useState(tls);
-
-  const reorder = (lists: TaskList[], startIndex: number, endIndex: number) => {
+export function BoardContent({ taskLists }: Props) {
+  const reorder = (
+    lists: TaskListType[],
+    startIndex: number,
+    endIndex: number,
+  ) => {
     const result = Array.from(lists);
     const [removed] = result.splice(startIndex, 1);
     result.splice(endIndex, 0, removed);
@@ -101,7 +94,7 @@ export function BoardContent() {
             {...provided.droppableProps}
             align='start'
           >
-            {taskLists.map(({ id, name, tasks }, index) => (
+            {taskLists.map(({ id, title, tasks }, index) => (
               <Draggable key={id} draggableId={id} index={index}>
                 {(provided) => (
                   <Flex
@@ -114,7 +107,7 @@ export function BoardContent() {
                       key={id}
                       listID={id}
                       tasks={tasks}
-                      listTitle={name}
+                      listTitle={title}
                     />
                   </Flex>
                 )}
@@ -127,84 +120,3 @@ export function BoardContent() {
     </DragDropContext>
   );
 }
-
-const tls = [
-  {
-    id: 'asdf1234',
-    name: 'Todo',
-    tasks: [
-      {
-        id: '1asdfzxcv',
-        name: 'Too long task name Too long task name Too long task name Too long task name Too long task name Too long task name Too long task name Too long task name Too long task name  ',
-        description: 'Description 1',
-        completed: false,
-      },
-      {
-        id: '2asdfcxzv',
-        name: 'Task 2asdf',
-        description: 'Description 2',
-        completed: false,
-      },
-      {
-        id: '3zxcvzxcv',
-        name: 'Taskasdfzxv 3',
-        description: 'Description 3',
-        completed: false,
-      },
-      {
-        id: '4qwerasdfsa',
-        name: 'Tsadfasask 4',
-        description: 'Description 3',
-        completed: false,
-      },
-    ],
-  },
-  {
-    id: 'asdf1235',
-    name: 'In progress',
-    tasks: [
-      {
-        id: '5asdfqasdf',
-        name: 'Tasqwerk 1',
-        description: 'Description 1',
-        completed: false,
-      },
-      {
-        id: '6asdfasdf',
-        name: 'Tasdfzxcvsk 2',
-        description: 'Description 2',
-        completed: false,
-      },
-      {
-        id: '7xcvzcv',
-        name: 'Tazxcvxsdfask 3',
-        description: 'Description 3',
-        completed: false,
-      },
-    ],
-  },
-  {
-    id: 'asdf1236',
-    name: 'Done',
-    tasks: [
-      {
-        id: '8zxcva',
-        name: 'Taswerqdsafk 1',
-        description: 'Description 1',
-        completed: false,
-      },
-      {
-        id: '9sadfsa',
-        name: 'Taxcfvadsk 2',
-        description: 'Description 2',
-        completed: false,
-      },
-      {
-        id: '10asdfasfd',
-        name: 'Tsdfasvcsask 3',
-        description: 'Description 3',
-        completed: false,
-      },
-    ],
-  },
-];

--- a/src/components/board-header/index.tsx
+++ b/src/components/board-header/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 import { HiPlus } from 'react-icons/hi';
 
 import { BoardHeaderMenu } from '@/components/board-header/board-header-menu';
-import { BoardActorContext } from '@/contexts/global-state-provider';
+import { BoardActorContext } from '@/contexts/board-actor-provider';
 import { boardTitleMachine } from '@/machines/board/board-title-machine';
 import {
   Button,

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,8 +1,14 @@
 import { Noto_Sans } from 'next/font/google';
+import { useEffect } from 'react';
+import useSWR from 'swr';
 
+import { getBoardsPath } from '@/api/boards/paths';
 import { SEO } from '@/components/layout/seo';
 import { Sidebar } from '@/components/layout/sidebar';
+import { BoardActorContext } from '@/contexts/board-actor-provider';
 import { Flex } from '@chakra-ui/react';
+
+import type { BoardType } from '@/types/board.type';
 
 interface Props {
   children: React.ReactNode;
@@ -14,6 +20,17 @@ const notoSans = Noto_Sans({
 });
 
 export function Layout({ children }: Props) {
+  const { data, error } = useSWR<BoardType[]>(getBoardsPath());
+  const boardActorRef = BoardActorContext.useActorRef();
+
+  useEffect(() => {
+    boardActorRef.send({
+      type: 'UPDATE_DATA',
+      payload: data,
+      error,
+    });
+  }, [boardActorRef, data, error]);
+
   return (
     <>
       <SEO />

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -1,28 +1,12 @@
 import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import useSWR from 'swr';
 
-import { getBoardsPath } from '@/api/boards/paths';
 import { NavItem } from '@/components/layout/nav-item';
-import { BoardActorContext } from '@/contexts/global-state-provider';
+import { useBoard } from '@/hooks/use-board';
 import { getBoardRoute } from '@/utils/routes';
 import { Flex } from '@chakra-ui/react';
 
-import type { Board } from '@/types/board.type';
-
 export function Nav() {
-  const router = useRouter();
-  const { data, error } = useSWR<Board[]>(getBoardsPath());
-  const [state, send] = BoardActorContext.useActor();
-
-  useEffect(() => {
-    send({
-      type: 'UPDATE_DATA',
-      payload: data,
-      error,
-    });
-  }, [data, error, send]);
+  const { boardID, boards } = useBoard();
 
   return (
     <Flex
@@ -37,13 +21,9 @@ export function Nav() {
       _hover={{ visibility: 'visible' }}
     >
       <Flex as='li' direction='column'>
-        {state.context.boards?.map(({ id, title }) => (
+        {boards?.map(({ id, title }) => (
           <Link key={id} href={getBoardRoute(id)}>
-            <NavItem
-              key={id}
-              content={title}
-              isCurrent={router.query.id === id}
-            />
+            <NavItem key={id} content={title} isCurrent={boardID === id} />
           </Link>
         ))}
       </Flex>

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 
 import { Nav } from '@/components/layout/nav';
-import { BoardActorContext } from '@/contexts/global-state-provider';
+import { BoardActorContext } from '@/contexts/board-actor-provider';
 import { Button, Flex } from '@chakra-ui/react';
 
 export function Sidebar() {
@@ -28,15 +28,6 @@ export function Sidebar() {
         pb={10}
         direction='column'
       >
-        {/* <Flex align='center' justify='space-between' px={3} py={2} _hover={{ bgColor: 'gray.100' }} borderRadius='md'>
-          <Flex gap={4} align='center'>
-            <Avatar size='md' name='Dan Abrahmov' src='https://bit.ly/dan-abramov' borderRadius='md' />
-            <Text fontWeight='bold' fontSize='lg'>
-              전병민
-            </Text>
-          </Flex>
-          <HiChevronDown fontSize={18} />
-        </Flex> */}
         <Button
           variant='outline'
           size='lg'

--- a/src/components/task-list/index.tsx
+++ b/src/components/task-list/index.tsx
@@ -4,17 +4,11 @@ import { Task } from '@/components/task';
 import { TaskListHeader } from '@/components/task-list/task-list-header';
 import { Flex } from '@chakra-ui/react';
 
-interface Task {
-  id: string;
-  name: string;
-  description: string;
-  completed: boolean;
-}
-
+import type { TaskType } from '@/types/task.type';
 interface Props {
   listID: string;
   listTitle: string;
-  tasks: Task[];
+  tasks: TaskType[];
 }
 
 export function TaskList({ listID, listTitle, tasks }: Props) {
@@ -34,7 +28,7 @@ export function TaskList({ listID, listTitle, tasks }: Props) {
         <Droppable droppableId={listID} type='task'>
           {(provided) => (
             <Flex ref={provided.innerRef} direction='column' w='full'>
-              {tasks.map(({ id, ...rest }, index) => (
+              {tasks.map(({ id, title }, index) => (
                 <Draggable key={id} draggableId={id} index={index}>
                   {(provided) => (
                     <Flex
@@ -43,7 +37,7 @@ export function TaskList({ listID, listTitle, tasks }: Props) {
                       {...provided.dragHandleProps}
                       w='full'
                     >
-                      <Task key={id} id={id} {...rest} />
+                      <Task key={id} title={title} />
                     </Flex>
                   )}
                 </Draggable>

--- a/src/components/task/index.tsx
+++ b/src/components/task/index.tsx
@@ -1,13 +1,10 @@
 import { Flex, Text } from '@chakra-ui/react';
 
 interface Props {
-  id: string;
-  name: string;
-  description: string;
-  completed: boolean;
+  title: string;
 }
 
-export function Task({ name }: Props) {
+export function Task({ title }: Props) {
   return (
     <Flex
       p={4}
@@ -21,7 +18,7 @@ export function Task({ name }: Props) {
       w='full'
       mb={4}
     >
-      <Text noOfLines={4}>{name}</Text>
+      <Text noOfLines={4}>{title}</Text>
     </Flex>
   );
 }

--- a/src/contexts/board-actor-provider.tsx
+++ b/src/contexts/board-actor-provider.tsx
@@ -1,0 +1,14 @@
+import { boardMachine } from '@/machines/board/board-machine';
+import { createActorContext } from '@xstate/react';
+
+export const BoardActorContext = createActorContext(boardMachine, {
+  devTools: true,
+});
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const BoardActorProvider = ({ children }: Props) => {
+  return <BoardActorContext.Provider>{children}</BoardActorContext.Provider>;
+};

--- a/src/contexts/board-id-provider.tsx
+++ b/src/contexts/board-id-provider.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { createContext } from 'react';
+import { createContext, useMemo } from 'react';
 
 export const BoardIDContext = createContext<string>('');
 
@@ -9,8 +9,12 @@ interface Props {
 
 export const BoardIDProvider = ({ children }: Props) => {
   const router = useRouter();
-  const queries = router.query['board-id'];
-  const boardID = Array.isArray(queries) ? queries[0] : queries ?? '';
+
+  const queries = useMemo(() => router.query['board-id'], [router.query]);
+
+  const boardID = useMemo(() => {
+    return Array.isArray(queries) ? queries[0] : queries ?? '';
+  }, [queries]);
 
   return (
     <BoardIDContext.Provider value={boardID}>

--- a/src/contexts/board-id-provider.tsx
+++ b/src/contexts/board-id-provider.tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router';
+import { createContext } from 'react';
+
+export const BoardIDContext = createContext<string>('');
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const BoardIDProvider = ({ children }: Props) => {
+  const router = useRouter();
+  const queries = router.query['board-id'];
+  const boardID = Array.isArray(queries) ? queries[0] : queries ?? '';
+
+  return (
+    <BoardIDContext.Provider value={boardID}>
+      {children}
+    </BoardIDContext.Provider>
+  );
+};

--- a/src/contexts/global-state-provider.tsx
+++ b/src/contexts/global-state-provider.tsx
@@ -1,14 +1,14 @@
-import { boardMachine } from '@/machines/board/board-machine';
-import { createActorContext } from '@xstate/react';
-
-export const BoardActorContext = createActorContext(boardMachine, {
-  devTools: true,
-});
+import { BoardActorProvider } from '@/contexts/board-actor-provider';
+import { BoardIDProvider } from '@/contexts/board-id-provider';
 
 interface Props {
   children: React.ReactNode;
 }
 
 export const GlobalStateProvider = ({ children }: Props) => {
-  return <BoardActorContext.Provider>{children}</BoardActorContext.Provider>;
+  return (
+    <BoardIDProvider>
+      <BoardActorProvider>{children}</BoardActorProvider>
+    </BoardIDProvider>
+  );
 };

--- a/src/hooks/use-board-id.ts
+++ b/src/hooks/use-board-id.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+
+import { BoardIDContext } from '@/contexts/board-id-provider';
+
+export function useBoardID() {
+  const boardID = useContext(BoardIDContext);
+  return boardID;
+}

--- a/src/hooks/use-board.ts
+++ b/src/hooks/use-board.ts
@@ -1,0 +1,14 @@
+import { BoardActorContext } from '@/contexts/board-actor-provider';
+import { useBoardID } from '@/hooks/use-board-id';
+
+export function useBoard() {
+  const boardID = useBoardID();
+
+  const boards = BoardActorContext.useSelector((state) => state.context.boards);
+
+  const board = BoardActorContext.useSelector((state) =>
+    state.context.boards?.find((b) => b.id === boardID),
+  );
+
+  return { boardID, boards, board };
+}

--- a/src/machines/board/board-machine.ts
+++ b/src/machines/board/board-machine.ts
@@ -12,19 +12,19 @@ import type {
   UpdateBoardParams,
   UpdateBoardBody,
 } from '@/api/boards/update-board';
-import type { Board } from '@/types/board.type';
+import type { BoardType } from '@/types/board.type';
 import type { ErrorType } from '@/types/error.type';
 
 const schema = {
   context: {} as {
-    boards: Board[] | null;
+    boards: BoardType[] | null;
     error: ErrorType;
   },
 
   events: {} as
     | {
         type: 'UPDATE_DATA';
-        payload: Board[] | undefined;
+        payload: BoardType[] | undefined;
         error: ErrorType;
       }
     | {
@@ -44,13 +44,13 @@ const schema = {
 
   services: {} as {
     addBoardActor: {
-      data: Board | null | undefined;
+      data: BoardType | null | undefined;
     };
     deleteBoardActor: {
-      data: Board[] | null | undefined;
+      data: BoardType[] | null | undefined;
     };
     updateBoardActor: {
-      data: Board[] | null | undefined;
+      data: BoardType[] | null | undefined;
     };
   },
 };
@@ -125,7 +125,7 @@ export const boardMachine = createMachine(
     actions: {
       updateData: assign({
         boards: (_, event) => {
-          const compare = (a: Board, b: Board) => {
+          const compare = (a: BoardType, b: BoardType) => {
             return b.updatedAt === a.updatedAt
               ? b.createdAt - a.createdAt
               : b.updatedAt - a.updatedAt;
@@ -188,14 +188,14 @@ export const boardMachine = createMachine(
   },
 );
 
-const createBoard = async (board: CreateBoardParams): Promise<Board> => {
+const createBoard = async (board: CreateBoardParams): Promise<BoardType> => {
   const data = await createBoardAPI(board);
 
   return data;
 };
 
 const updateBoard = async (
-  boards: Board[] | null,
+  boards: BoardType[] | null,
   board: UpdateBoardParams & UpdateBoardBody,
 ) => {
   if (!boards) {
@@ -215,7 +215,7 @@ const updateBoard = async (
   return boards;
 };
 
-const deleteBoard = async (boards: Board[] | null, id: string) => {
+const deleteBoard = async (boards: BoardType[] | null, id: string) => {
   if (!boards) {
     return null;
   }

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -1,6 +1,6 @@
 import type { GetServerSideProps } from 'next';
 
-import type { Board } from '@/types/board.type';
+import type { BoardType } from '@/types/board.type';
 import { getBoardsAPI } from '@/api/boards/get-board';
 
 export default function BoardPage() {
@@ -10,7 +10,7 @@ export default function BoardPage() {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const {} = context;
 
-  const compare = (a: Board, b: Board) => {
+  const compare = (a: BoardType, b: BoardType) => {
     if (b.updatedAt === a.updatedAt) {
       return b.createdAt - a.createdAt;
     }

--- a/src/types/board.type.ts
+++ b/src/types/board.type.ts
@@ -1,4 +1,4 @@
-export interface Board {
+export interface BoardType {
   id: string;
   title: string;
   createdAt: number;

--- a/src/types/task-list.type.ts
+++ b/src/types/task-list.type.ts
@@ -1,6 +1,6 @@
 import type { Task } from '@/types/task.type';
 
-export interface TaskList {
+export interface TaskListType {
   id: string;
   title: string;
   boardId: string;

--- a/src/types/task-list.type.ts
+++ b/src/types/task-list.type.ts
@@ -1,8 +1,8 @@
-import type { Task } from '@/types/task.type';
+import type { TaskType } from '@/types/task.type';
 
 export interface TaskListType {
   id: string;
   title: string;
   boardId: string;
-  tasks: Task[];
+  tasks: TaskType[];
 }

--- a/src/types/task.type.ts
+++ b/src/types/task.type.ts
@@ -1,4 +1,4 @@
-export interface Task {
+export interface TaskType {
   id: string;
   title: string;
 }


### PR DESCRIPTION
## 📄 구현 내용 설명
board hook을 통해 필요한 데이터(e.g. board, boards, boardID)를 주입받도록 변경하였습니다.

### ⛱️ 주요 변경 사항
- `BoardIDProvider`를 `GlobalStateProvider`에 통합하여 board-id값이 변경될 때마다 새로운 `boardID` 를 반환할 수 있도록 수정하였습니다. 이제 `useBoardID` 를 통해 `boardID` 를 가져올 수 있습니다.
- 이제 `BoardActorContext` 의 select를 모두 `useBoard` 내에서 합니다. `useBoard` 훅을 사용하여 board, boards, boardID 데이터를 가져올 수 있습니다. (`BoardActor`는 GlobalState에 항상 존재합니다.)
- **주의: `boardID`값이 없는 곳에서 `board`는 undefined 값을 갖습니다. 이에 대해 발생할 수 있는 개발자의 실수를 줄이는 방법에 대해 고민이 필요합니다.**


#### useBoard
```js
export function useBoard() {
  const boardID = useBoardID();

  const boards = BoardActorContext.useSelector((state) => state.context.boards);

  const board = BoardActorContext.useSelector((state) =>
    state.context.boards?.find((b) => b.id === boardID),
  );

  return { boardID, boards, board };
}

```

#### consume
```js
const { boardID, board, boards } = useBoard();
```